### PR TITLE
feat(experimental): define Aggregate interface for event sourcing

### DIFF
--- a/packages/experimental/src/Aggregate.ts
+++ b/packages/experimental/src/Aggregate.ts
@@ -1,0 +1,33 @@
+import type * as Event from "./Event.ts"
+
+/**
+ * Represents an aggregate, which is a fundamental concept in Domain-Driven Design.
+ * An aggregate is a cluster of domain objects that can be treated as a single unit.
+ *
+ * @template S The type of the aggregate's state.
+ * @template E The type of the events that can be applied to the aggregate.
+ */
+export interface Aggregate<S, E extends Event.Any> {
+  /**
+   * The unique identifier of the aggregate.
+   */
+  readonly id: string
+
+  /**
+   * The current version of the aggregate.
+   * This version is incremented each time an event is applied.
+   */
+  readonly version: number
+
+  /**
+   * A list of events that have occurred but have not yet been persisted.
+   * These are new changes to the aggregate's state.
+   */
+  readonly uncommittedChanges: ReadonlyArray<E>
+
+  /**
+   * The current state of the aggregate.
+   * This state is derived by applying all historical events.
+   */
+  readonly state: S
+}

--- a/packages/experimental/test/Aggregate.test.ts
+++ b/packages/experimental/test/Aggregate.test.ts
@@ -1,0 +1,42 @@
+import * as Aggregate from "../src/Aggregate.ts"
+import * as Event from "@effect/experimental/Event"
+import * as Schema from "@effect/schema/Schema"
+import { describe, it, expect } from "vitest"
+
+// Define a sample event type
+const UserCreated = Event.make<"UserCreated", { userId: Schema.String, name: Schema.String }>("UserCreated")({
+  userId: Schema.String,
+  name: Schema.String
+})
+
+// Define a sample state interface
+interface UserState {
+  readonly userId: string
+  readonly name: string
+  readonly status: string
+}
+
+describe("Aggregate", () => {
+  it("should allow creation of a valid Aggregate object", () => {
+    // Create a sample UserCreated event instance
+    const userCreatedEvent = UserCreated({ userId: "user-123", name: "John Doe" })
+
+    // Create an object that conforms to Aggregate<UserState, ReturnType<typeof UserCreated>>
+    const aggregate: Aggregate.Aggregate<UserState, typeof UserCreated> = {
+      id: "aggregate-1",
+      version: 1,
+      uncommittedChanges: [userCreatedEvent],
+      state: {
+        userId: "user-123",
+        name: "John Doe",
+        status: "active"
+      }
+    }
+
+    // Basic assertion
+    expect(aggregate.id).toBe("aggregate-1")
+    expect(aggregate.version).toBe(1)
+    expect(aggregate.uncommittedChanges).toEqual([userCreatedEvent])
+    expect(aggregate.state.status).toBe("active")
+  })
+})


### PR DESCRIPTION
Defines the initial `Aggregate` interface within the experimental event sourcing module.

The `Aggregate` interface includes:
- Generic types for state (`S`) and event (`E extends Event.Any`).
- Properties: `id`, `version`, `uncommittedChanges`, and `state`.

Also adds a basic unit test for the `Aggregate` interface, demonstrating its usage with sample event and state types.